### PR TITLE
Change profiling to use ENABLE_PROFILING environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ poetry install
 
 export IGLO_DB_PORT=15432  # envvar needed for manage and other commands
 export CELERY_TASK_ALWAYS_EAGER=True
+# export ENABLE_PROFILING=True  # Uncomment to enable performance profiling
 alias manage="poetry run python3 iglo/manage.py"
 
 # Start Postgres
@@ -83,6 +84,29 @@ Method for accurating only:
 poetry cache clear PyPI --all  # sometimes
 poetry add accurating@latest
 ```
+
+### Performance Profiling
+
+IGLO includes a performance profiling system that helps identify and fix bottlenecks like N+1 query issues.
+To enable the profiling system:
+
+```bash
+export ENABLE_PROFILING=True
+```
+
+After enabling profiling and running some pages, you can view a performance summary in the Django shell:
+
+```bash
+manage shell
+```
+
+```python
+from logging import getLogger
+logger = getLogger('misc.middleware')
+print(logger.dump_profile_stats())  # Shows performance stats summary
+```
+
+**Note**: Only enable profiling during development as it adds overhead to request processing.
 
 ### Celery dev run.
 Should not be needed because we run iglo with CELERY_TASK_ALWAYS_EAGER=True

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ poetry install
 
 export IGLO_DB_PORT=15432  # envvar needed for manage and other commands
 export CELERY_TASK_ALWAYS_EAGER=True
-# export ENABLE_PROFILING=True  # Uncomment to enable performance profiling
+export ENABLE_PROFILING=False  # Uncomment to enable performance profiling
 alias manage="poetry run python3 iglo/manage.py"
 
 # Start Postgres

--- a/iglo/iglo/settings.py
+++ b/iglo/iglo/settings.py
@@ -287,6 +287,7 @@ LOCALE_PATHS = [
 ENABLE_AI_ANALYSE_UPLOAD = env("ENABLE_AI_ANALYSE_UPLOAD", as_bool=True, default=False)
 ENABLE_UPCOMING_GAMES_REMINDER = env("ENABLE_UPCOMING_GAMES_REMINDER", as_bool=True, default=True)
 ENABLE_DELAYED_GAMES_REMINDER = env("ENABLE_DELAYED_GAMES_REMINDER", as_bool=True, default=False)
+ENABLE_PROFILING = env("ENABLE_PROFILING", as_bool=True, default=False)
 
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',

--- a/iglo/misc/middleware.py
+++ b/iglo/misc/middleware.py
@@ -126,7 +126,8 @@ class ProfilingMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if not settings.DEBUG:
+        # Only run profiling if explicitly enabled via environment variable
+        if not getattr(settings, 'ENABLE_PROFILING', False):
             return self.get_response(request)
             
         # Reset queries to ensure we only capture this request


### PR DESCRIPTION
- Add new ENABLE_PROFILING environment variable in settings.py (default: False)
- Update ProfilingMiddleware to only run when ENABLE_PROFILING is True
- Add documentation to README about the profiling system and how to use it
- Decouple profiling from DEBUG mode to avoid performance issues in development
- Make profiling an explicit opt-in feature for better performance control