### PR TITLE
Add Alternative Game Views for League Groups

### DIFF
--- a/iglo/league/urls.py
+++ b/iglo/league/urls.py
@@ -6,6 +6,7 @@ from league.views import (
     SeasonDetailView,
     SeasonDeleteView,
     GroupDetailView,
+    GroupGamesView,
     GameDetailView,
     PlayerDetailView,
     PlayerUpdateView,
@@ -31,6 +32,7 @@ urlpatterns = [
         RedirectView.as_view(permanent=True, pattern_name="group-detail"),
         name="deprecated-group-detail",
     ),
+    path("seasons/<int:season_number>/groups/<group_name>/games", GroupGamesView.as_view(), name="group-games"),
     path("seasons/<int:season_number>/groups/<group_name>/egd", GroupEGDExportView.as_view(), name="group-egd-export"),
     path(
         "seasons/<int:season_number>/groups/<group_name>/games/<black_player>-<white_player>",

--- a/iglo/league/urls.py
+++ b/iglo/league/urls.py
@@ -7,6 +7,7 @@ from league.views import (
     SeasonDeleteView,
     GroupDetailView,
     GroupGamesView,
+    GroupAllGamesView,
     GameDetailView,
     PlayerDetailView,
     PlayerUpdateView,
@@ -33,6 +34,7 @@ urlpatterns = [
         name="deprecated-group-detail",
     ),
     path("seasons/<int:season_number>/groups/<group_name>/games", GroupGamesView.as_view(), name="group-games"),
+    path("seasons/<int:season_number>/groups/<group_name>/all-games", GroupAllGamesView.as_view(), name="group-all-games"),
     path("seasons/<int:season_number>/groups/<group_name>/egd", GroupEGDExportView.as_view(), name="group-egd-export"),
     path(
         "seasons/<int:season_number>/groups/<group_name>/games/<black_player>-<white_player>",

--- a/iglo/league/views.py
+++ b/iglo/league/views.py
@@ -220,6 +220,18 @@ class GroupDetailView(UserRoleRequiredForModify, GroupObjectMixin, DetailView):
         return super().get(request, *args, **kwargs)
 
 
+class GroupGamesView(UserRoleRequiredForModify, GroupObjectMixin, DetailView):
+    model = Group
+    required_roles = [UserRole.REFEREE]
+    template_name = 'league/group_games.html'
+    
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if "action-pairing" in request.POST:
+            self.object.start_macmahon_round()
+        return super().get(request, *args, **kwargs)
+
+
 class GroupEGDExportView(UserRoleRequired, GroupObjectMixin, DetailView):
     model = Group
     required_roles = [UserRole.REFEREE]

--- a/iglo/league/views.py
+++ b/iglo/league/views.py
@@ -232,6 +232,27 @@ class GroupGamesView(UserRoleRequiredForModify, GroupObjectMixin, DetailView):
         return super().get(request, *args, **kwargs)
 
 
+class GroupAllGamesView(UserRoleRequiredForModify, GroupObjectMixin, DetailView):
+    model = Group
+    required_roles = [UserRole.REFEREE]
+    template_name = 'league/group_all_games.html'
+    
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        
+        # Get all games from the group and exclude byes
+        games = Game.objects.filter(group=self.object).exclude(win_type=WinType.BYE)
+        
+        # Custom sort by initial order of both players, higher player first
+        games = sorted(games, key=lambda game: (
+            min(game.black.order, game.white.order),
+            max(game.black.order, game.white.order)
+        ))
+        
+        context['all_games'] = games
+        return context
+
+
 class GroupEGDExportView(UserRoleRequired, GroupObjectMixin, DetailView):
     model = Group
     required_roles = [UserRole.REFEREE]

--- a/iglo/league/views.py
+++ b/iglo/league/views.py
@@ -250,6 +250,12 @@ class GroupAllGamesView(UserRoleRequiredForModify, GroupObjectMixin, DetailView)
         ))
         
         context['all_games'] = games
+        
+        # Generate options for grouping dropdown based on number of games
+        game_count = len(games)
+        group_options = list(range(1, game_count + 1))  # All possible options
+        context['group_options'] = group_options
+        
         return context
 
 

--- a/iglo/templates/league/group_all_games.html
+++ b/iglo/templates/league/group_all_games.html
@@ -62,7 +62,8 @@
                         <th>{% translate "Biały" %}</th>
                         <th>{% translate "Wynik" %}</th>
                         <th>{% translate "Data" %}</th>
-                        <th></th>
+                        <th>{% translate "Recenzja" %}</th>
+                        <th>{% translate "Akcje" %}</th>
                         <th class="group-column text-center bg-primary text-white" style="display: none;">{% translate "Grupa Nauczycielska" %}</th>
                     </tr>
                 </thead>
@@ -71,15 +72,23 @@
                         <tr>
                             <td>{{ game.round.number }}</td>
                             <td>
-                                {{ game.black.player.nick }} ({{ game.black.rank }})
+                                <a href="{{ game.black.player.get_absolute_url }}">
+                                    {{ game.black.player.nick }} ({{ game.black.rank }})
+                                </a>
                                 {% if game.black.player.is_supporter %}
-                                    <i class="fas fa-award text-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate "Ten gracz jest patronem IGLO!" %}"></i>
+                                    <span class="badge bg-warning text-dark ms-1" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate "Ten gracz jest patronem IGLO!" %}">
+                                        <i class="fas fa-award"></i> Patron
+                                    </span>
                                 {% endif %}
                             </td>
                             <td>
-                                {{ game.white.player.nick }} ({{ game.white.rank }})
+                                <a href="{{ game.white.player.get_absolute_url }}">
+                                    {{ game.white.player.nick }} ({{ game.white.rank }})
+                                </a>
                                 {% if game.white.player.is_supporter %}
-                                    <i class="fas fa-award text-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate "Ten gracz jest patronem IGLO!" %}"></i>
+                                    <span class="badge bg-warning text-dark ms-1" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate "Ten gracz jest patronem IGLO!" %}">
+                                        <i class="fas fa-award"></i> Patron
+                                    </span>
                                 {% endif %}
                             </td>
                             <td>
@@ -99,6 +108,15 @@
                                 {% endif %}
                             </td>
                             <td>
+                                {% if game.review_video_link %}
+                                    <a href="{{ game.review_video_link }}" target="_blank" class="badge bg-success text-decoration-none">
+                                        <i class="fas fa-video"></i> {% translate "Zobacz recenzję" %}
+                                    </a>
+                                {% else %}
+                                    <span class="text-muted">{% translate "Brak recenzji" %}</span>
+                                {% endif %}
+                            </td>
+                            <td>
                                 <a href="{{ game.get_absolute_url }}" class="btn btn-sm btn-outline-secondary">
                                     <i class="fas fa-eye"></i>
                                 </a>
@@ -107,7 +125,7 @@
                         </tr>
                     {% empty %}
                         <tr>
-                            <td colspan="7" class="text-center">{% translate "Brak gier w tej grupie." %}</td>
+                            <td colspan="8" class="text-center">{% translate "Brak gier w tej grupie." %}</td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/iglo/templates/league/group_all_games.html
+++ b/iglo/templates/league/group_all_games.html
@@ -28,44 +28,47 @@
             </nav>
             
             <div class="d-flex justify-content-between mb-2">
-                <h3>{% translate "Wszystkie gry" %} - {% translate "Grupa" %} {{ object.name }}</h3>
+                <h3>{% translate "Wszystkie gry" %} - {% translate "Grupa Nauczycielska" %} {{ object.name }}</h3>
                 <div class="d-flex align-items-center">
-                    <div class="me-3">
-                        <label for="groupSize" class="me-2">{% translate "Grupuj po" %}:</label>
-                        <select id="groupSize" class="form-select form-select-sm" style="width: auto; display: inline-block;">
-                            <option value="0">{% translate "Brak" %}</option>
-                            {% for i in group_options %}
-                                <option value="{{ i }}">{{ i }}</option>
-                            {% endfor %}
-                        </select>
-                    </div>
                     <div>
                         <a href="{% url 'group-games' season_number=object.season.number group_name=object.name %}" class="btn btn-sm btn-primary me-1">
                             <i class="fa fa-list"></i> {% translate "Widok rund" %}
                         </a>
                         <a href="{% url 'group-detail' season_number=object.season.number group_name=object.name %}" class="btn btn-sm btn-secondary">
-                            <i class="fa fa-arrow-left"></i> {% translate "Grupa" %}
+                            <i class="fa fa-arrow-left"></i> {% translate "Grupa Nauczycielska" %}
                         </a>
                     </div>
+                </div>
+            </div>
+            
+            <div class="mb-3 p-3 bg-light rounded">
+                <div class="d-flex align-items-center">
+                    <label for="groupSize" class="form-label fw-bold me-3 mb-0">{% translate "Grupuj dla Nauczycieli" %}:</label>
+                    <select id="groupSize" class="form-select" style="width: auto;">
+                        <option value="0">{% translate "Brak" %}</option>
+                        {% for i in group_options %}
+                            <option value="{{ i }}">{{ i }}</option>
+                        {% endfor %}
+                    </select>
+                    <span class="ms-3 text-muted">{% translate "Wybierz liczbę gier w grupie dla łatwego przydzielenia zadań nauczycielskich" %}</span>
                 </div>
             </div>
 
             <table class="table table-sm table-hover table-striped">
                 <thead class="table-light">
                     <tr>
-                        <th class="group-column" style="display: none;">{% translate "Grupa" %}</th>
                         <th>R</th>
                         <th>{% translate "Czarny" %}</th>
                         <th>{% translate "Biały" %}</th>
                         <th>{% translate "Wynik" %}</th>
                         <th>{% translate "Data" %}</th>
                         <th></th>
+                        <th class="group-column text-center bg-primary text-white" style="display: none;">{% translate "Grupa Nauczycielska" %}</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for game in all_games %}
                         <tr>
-                            <td class="group-column" style="display: none;"></td>
                             <td>{{ game.round.number }}</td>
                             <td>
                                 {{ game.black.player.nick }} ({{ game.black.rank }})
@@ -100,10 +103,11 @@
                                     <i class="fas fa-eye"></i>
                                 </a>
                             </td>
+                            <td class="group-column text-center fw-bold" style="display: none;"></td>
                         </tr>
                     {% empty %}
                         <tr>
-                            <td colspan="6" class="text-center">{% translate "Brak gier w tej grupie." %}</td>
+                            <td colspan="7" class="text-center">{% translate "Brak gier w tej grupie." %}</td>
                         </tr>
                     {% endfor %}
                 </tbody>
@@ -166,8 +170,10 @@
                         row.style.backgroundColor = groupColors[colorIndex];
                         
                         // Set group number (add 1 for human-readable group numbers starting at 1)
-                        if (row.cells[0].classList.contains('group-column')) {
-                            row.cells[0].textContent = groupIndex + 1;
+                        // Find the group column (last cell)
+                        const groupCell = row.querySelector('.group-column');
+                        if (groupCell) {
+                            groupCell.textContent = groupIndex + 1;
                         }
                     }
                 });

--- a/iglo/templates/league/group_all_games.html
+++ b/iglo/templates/league/group_all_games.html
@@ -29,19 +29,31 @@
             
             <div class="d-flex justify-content-between mb-2">
                 <h3>{% translate "Wszystkie gry" %} - {% translate "Grupa" %} {{ object.name }}</h3>
-                <div>
-                    <a href="{% url 'group-games' season_number=object.season.number group_name=object.name %}" class="btn btn-sm btn-primary me-1">
-                        <i class="fa fa-list"></i> {% translate "Widok rund" %}
-                    </a>
-                    <a href="{% url 'group-detail' season_number=object.season.number group_name=object.name %}" class="btn btn-sm btn-secondary">
-                        <i class="fa fa-arrow-left"></i> {% translate "Grupa" %}
-                    </a>
+                <div class="d-flex align-items-center">
+                    <div class="me-3">
+                        <label for="groupSize" class="me-2">{% translate "Grupuj po" %}:</label>
+                        <select id="groupSize" class="form-select form-select-sm" style="width: auto; display: inline-block;">
+                            <option value="0">{% translate "Brak" %}</option>
+                            {% for i in group_options %}
+                                <option value="{{ i }}">{{ i }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div>
+                        <a href="{% url 'group-games' season_number=object.season.number group_name=object.name %}" class="btn btn-sm btn-primary me-1">
+                            <i class="fa fa-list"></i> {% translate "Widok rund" %}
+                        </a>
+                        <a href="{% url 'group-detail' season_number=object.season.number group_name=object.name %}" class="btn btn-sm btn-secondary">
+                            <i class="fa fa-arrow-left"></i> {% translate "Grupa" %}
+                        </a>
+                    </div>
                 </div>
             </div>
 
             <table class="table table-sm table-hover table-striped">
                 <thead class="table-light">
                     <tr>
+                        <th class="group-column" style="display: none;">{% translate "Grupa" %}</th>
                         <th>R</th>
                         <th>{% translate "Czarny" %}</th>
                         <th>{% translate "Biały" %}</th>
@@ -53,9 +65,20 @@
                 <tbody>
                     {% for game in all_games %}
                         <tr>
+                            <td class="group-column" style="display: none;"></td>
                             <td>{{ game.round.number }}</td>
-                            <td>{{ game.black.player.nick }} ({{ game.black.rank }})</td>
-                            <td>{{ game.white.player.nick }} ({{ game.white.rank }})</td>
+                            <td>
+                                {{ game.black.player.nick }} ({{ game.black.rank }})
+                                {% if game.black.player.is_supporter %}
+                                    <i class="fas fa-award text-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate "Ten gracz jest patronem IGLO!" %}"></i>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {{ game.white.player.nick }} ({{ game.white.rank }})
+                                {% if game.white.player.is_supporter %}
+                                    <i class="fas fa-award text-warning" data-bs-toggle="tooltip" data-bs-placement="top" title="{% translate "Ten gracz jest patronem IGLO!" %}"></i>
+                                {% endif %}
+                            </td>
                             <td>
                                 {% if game.is_played %}
                                     {{ game | result }}
@@ -87,4 +110,71 @@
             </table>
         </div>
     </div>
+    
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            const groupSizeSelect = document.getElementById('groupSize');
+            const gameRows = document.querySelectorAll('tbody tr');
+            const groupColumns = document.querySelectorAll('.group-column');
+            const groupColors = [
+                'rgba(255, 99, 132, 0.2)',   // Red
+                'rgba(54, 162, 235, 0.2)',   // Blue
+                'rgba(255, 206, 86, 0.2)',   // Yellow
+                'rgba(75, 192, 192, 0.2)',   // Teal
+                'rgba(153, 102, 255, 0.2)',  // Purple
+                'rgba(255, 159, 64, 0.2)',   // Orange
+                'rgba(199, 199, 199, 0.2)',  // Grey
+                'rgba(83, 123, 156, 0.2)',   // Blue Grey
+                'rgba(172, 212, 89, 0.2)',   // Light Green
+                'rgba(250, 160, 160, 0.2)'   // Light Red
+            ];
+            
+            // Enable tooltips
+            const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+            tooltipTriggerList.map(function (tooltipTriggerEl) {
+                return new bootstrap.Tooltip(tooltipTriggerEl);
+            });
+            
+            // Function to apply group coloring and numbering
+            function applyGrouping() {
+                const groupSize = parseInt(groupSizeSelect.value, 10);
+                
+                // Reset all row backgrounds and hide group columns
+                gameRows.forEach(row => {
+                    row.style.backgroundColor = '';
+                });
+                
+                groupColumns.forEach(col => {
+                    col.style.display = 'none';
+                });
+                
+                // If groupSize is 0, exit early
+                if (groupSize === 0) return;
+                
+                // Show group columns
+                groupColumns.forEach(col => {
+                    col.style.display = '';
+                });
+                
+                // Apply colors and group numbers for each group
+                gameRows.forEach((row, index) => {
+                    if (row.cells.length > 1) { // Skip "No games" row if present
+                        const groupIndex = Math.floor(index / groupSize);
+                        const colorIndex = groupIndex % groupColors.length;
+                        
+                        // Set background color
+                        row.style.backgroundColor = groupColors[colorIndex];
+                        
+                        // Set group number (add 1 for human-readable group numbers starting at 1)
+                        if (row.cells[0].classList.contains('group-column')) {
+                            row.cells[0].textContent = groupIndex + 1;
+                        }
+                    }
+                });
+            }
+            
+            // Apply grouping on dropdown change
+            groupSizeSelect.addEventListener('change', applyGrouping);
+        });
+    </script>
 {% endblock %}

--- a/iglo/templates/league/group_all_games.html
+++ b/iglo/templates/league/group_all_games.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+
+{% load static i18n %}
+{% load game_result %}
+
+{% block page_title %}{% translate "Sezon" %} #{{ object.season.number }} - {% translate "Grupa" %}
+    {{ object.name }} - {% translate "Wszystkie gry" %}{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col">
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item">
+                        <a href="{% url "seasons-list" %}">{% translate "Sezony" %}</a>
+                    </li>
+                    <li class="breadcrumb-item">
+                        <a href="{% url "season-detail" object.season.number %}">
+                            {% translate "Sezon" %} #{{ object.season.number }}
+                        </a>
+                    </li>
+                    <li class="breadcrumb-item">
+                        <a href="{% url "group-detail" season_number=object.season.number group_name=object.name %}">
+                            {% translate "Grupa" %} {{ object.name }}
+                        </a>
+                    </li>
+                </ol>
+            </nav>
+            
+            <div class="d-flex justify-content-between mb-2">
+                <h3>{% translate "Wszystkie gry" %} - {% translate "Grupa" %} {{ object.name }}</h3>
+                <div>
+                    <a href="{% url 'group-games' season_number=object.season.number group_name=object.name %}" class="btn btn-sm btn-primary me-1">
+                        <i class="fa fa-list"></i> {% translate "Widok rund" %}
+                    </a>
+                    <a href="{% url 'group-detail' season_number=object.season.number group_name=object.name %}" class="btn btn-sm btn-secondary">
+                        <i class="fa fa-arrow-left"></i> {% translate "Grupa" %}
+                    </a>
+                </div>
+            </div>
+
+            <table class="table table-sm table-hover table-striped">
+                <thead class="table-light">
+                    <tr>
+                        <th>R</th>
+                        <th>{% translate "Czarny" %}</th>
+                        <th>{% translate "Biały" %}</th>
+                        <th>{% translate "Wynik" %}</th>
+                        <th>{% translate "Data" %}</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for game in all_games %}
+                        <tr>
+                            <td>{{ game.round.number }}</td>
+                            <td>{{ game.black.player.nick }} ({{ game.black.rank }})</td>
+                            <td>{{ game.white.player.nick }} ({{ game.white.rank }})</td>
+                            <td>
+                                {% if game.is_played %}
+                                    {{ game | result }}
+                                {% else %}
+                                    -
+                                {% endif %}
+                                {% if game.is_egd_eligible %}
+                                    <span class="badge bg-info ms-1" title="{% translate 'This game is eligible for EGD export' %}">EGD</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {{ game.date|date:"Y-m-d" }}
+                                {% if game.is_delayed %}
+                                    <i class="fas fa-exclamation-triangle text-danger"></i>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <a href="{{ game.get_absolute_url }}" class="btn btn-sm btn-outline-secondary">
+                                    <i class="fas fa-eye"></i>
+                                </a>
+                            </td>
+                        </tr>
+                    {% empty %}
+                        <tr>
+                            <td colspan="6" class="text-center">{% translate "Brak gier w tej grupie." %}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+{% endblock %}

--- a/iglo/templates/league/group_detail.html
+++ b/iglo/templates/league/group_detail.html
@@ -172,10 +172,14 @@
                             <span class="text-muted small">{% blocktrans %}Jak czytać wyniki?{% endblocktrans %}</span></a>
                     </div>
                 </div>
+                
                 <div class="d-flex justify-content-between mb-4">
                     <h3>Gry</h3>
-                    {% if user|has_role:'referee' %}
-                        <div>
+                    <div>
+                        <a href="{% url 'group-games' season_number=object.season.number group_name=object.name %}" class="btn btn-primary">
+                            <i class="fa fa-list"></i> {% translate "Zobacz wszystkie gry" %}
+                        </a>
+                        {% if user|has_role:'referee' %}
                             {% if group.season.state == "in_progress" and group.type == "mcmahon" and group.all_games_finished %}
                                 <form method="post" class="d-inline-block">{% csrf_token %}
                                     <button type="submit" class="btn btn-primary" name="action-pairing">
@@ -189,70 +193,9 @@
                                     <i class="fa fa-file-export"></i> {% blocktrans %}Eksport EGD{% endblocktrans %}
                                 </a>
                             {% endif %}
-                        </div>
-                    {% endif %}
-                </div>
-                {% for round in object.rounds.all %}
-                    <div class="card mb-3">
-                        <div class="card-header d-flex justify-content-between align-items-center clickable flex-column flex-md-row align-items-stretch align-items-md-baseline"
-                             onClick="toggle_collapse(event)" data-target="round-{{ forloop.counter }}">
-                            <div class="d-flex flex-grow-1">
-                                <strong class="flex-grow-1">{% translate "Runda" %} #{{ round.number }}</strong>
-                                <div>
-                                    {% if round.start_date and round.end_date %}{{ round.start_date }} -
-                                        {{ round.end_date }}{% endif %}
-                                </div>
-                            </div>
-                            <button class="btn" onClick="toggle_collapse(event)"
-                                    data-target="round-{{ forloop.counter }}">
-                                <i id="collapse-round-{{ forloop.counter }}" style="pointer-events: none;" class="fas
-                                   {% if round.is_current %} fa-chevron-up {% else %} fa-chevron-down {% endif %}"></i>
-                            </button>
-                        </div>
-                        <div class="card-body collapse {% if round.is_current %}show{% endif %}"
-                             id="round-{{ forloop.counter }}">
-                            {% for game in round.games.all %}
-                                <div class="card mb-3 {% if not game.is_bye and game.is_egd_eligible %}border-info{% endif %}">
-                                    <div class="card-header d-flex justify-content-between {% if not game.is_bye and game.is_egd_eligible %}bg-light{% endif %}">
-                                    <span>
-                                        {% if game.is_bye %}
-                                            {% translate "Bye" %}:
-                                            {% include "league/includes/player_badge.html" with player=game.winner.player member=game.winner %}
-                                        {% else %}
-                                            {% include "league/includes/game_players.html" with game=game %}
-                                            {% if game.is_egd_eligible %}
-                                                <span class="badge bg-info ms-2" title="{% translate 'This game is eligible for EGD export' %}">EGD</span>
-                                            {% endif %}
-                                        {% endif %}
-                                    </span>
-                                        {% if game.date and not game.is_bye %}
-                                            <span>
-                                                {{ game.date }}
-                                                {% if game.is_delayed %}
-                                                    <i class="fas fa-exclamation-triangle text-danger"
-                                                       data-bs-toggle="tooltip" data-bs-placement="top"
-                                                       title="{% translate "Ta gra nie została rozegrana w terminie" %}"></i>
-                                                {% endif %}
-                                            </span>
-                                        {% endif %}
-                                    </div>
-                                    <div class="card-body d-flex justify-content-between align-items-baseline flex-wrap">
-                                        <p>
-                                            {% if game.is_played %}
-                                                {{ game | result }}
-                                            {% else %}
-                                                {% blocktrans trimmed %}Gra jeszcze się nie odbyła.{% endblocktrans %}
-                                            {% endif %}
-                                        </p>
-                                        <div>
-                                            {% include "league/includes/game_actions.html" with show_link=True %}
-                                        </div>
-                                    </div>
-                                </div>
-                            {% endfor %}
-                        </div>
+                        {% endif %}
                     </div>
-                {% endfor %}
+                </div>
             {% elif object.season.state == "draft" %}
                 <div class="d-flex justify-content-between mb-3">
                     <h3>{% translate "Gracze" %}</h3>

--- a/iglo/templates/league/group_detail.html
+++ b/iglo/templates/league/group_detail.html
@@ -176,12 +176,15 @@
                 <div class="d-flex justify-content-between mb-4">
                     <h3>Gry</h3>
                     <div>
-                        <a href="{% url 'group-games' season_number=object.season.number group_name=object.name %}" class="btn btn-primary">
-                            <i class="fa fa-list"></i> {% translate "Zobacz wszystkie gry" %}
+                        <a href="{% url 'group-games' season_number=object.season.number group_name=object.name %}" class="btn btn-primary me-2">
+                            <i class="fa fa-list"></i> {% translate "Gry według rund" %}
+                        </a>
+                        <a href="{% url 'group-all-games' season_number=object.season.number group_name=object.name %}" class="btn btn-primary">
+                            <i class="fa fa-th-list"></i> {% translate "Wszystkie gry" %}
                         </a>
                         {% if user|has_role:'referee' %}
                             {% if group.season.state == "in_progress" and group.type == "mcmahon" and group.all_games_finished %}
-                                <form method="post" class="d-inline-block">{% csrf_token %}
+                                <form method="post" class="d-inline-block ms-2">{% csrf_token %}
                                     <button type="submit" class="btn btn-primary" name="action-pairing">
                                         <i class="fa fa-table"></i> {% blocktrans %}Nowa runda{% endblocktrans %}
                                     </button>
@@ -189,7 +192,7 @@
                             {% endif %}
                             {% if group.all_games_finished %}
                                 <a href="{% url "group-egd-export" season_number=group.season.number group_name=group.name %}"
-                                   class="btn btn-primary">
+                                   class="btn btn-primary ms-2">
                                     <i class="fa fa-file-export"></i> {% blocktrans %}Eksport EGD{% endblocktrans %}
                                 </a>
                             {% endif %}

--- a/iglo/templates/league/group_detail.html
+++ b/iglo/templates/league/group_detail.html
@@ -27,8 +27,17 @@
                 <h2>{% translate "Grupa" %} {{ object.name }}</h2>
                 <span class="badge bg-secondary ms-2">{{ group.get_type_display | upper }}</span>
 
+                <div class="ms-auto">
+                    <a href="{% url 'group-games' season_number=object.season.number group_name=object.name %}" class="btn btn-primary me-2">
+                        <i class="fa fa-list"></i> {% translate "Gry według rund" %}
+                    </a>
+                    <a href="{% url 'group-all-games' season_number=object.season.number group_name=object.name %}" class="btn btn-primary">
+                        <i class="fa fa-th-list"></i> {% translate "Wszystkie gry" %}
+                    </a>
+                </div>
+
                 {% if group.teacher %}
-                    <div class="ms-auto">
+                    <div class="ms-3">
                         {% translate "Nauczyciel" %}: {% include "review/includes/teacher_badge.html" with teacher=group.teacher %}
                     </div>
                 {% endif %}
@@ -176,15 +185,9 @@
                 <div class="d-flex justify-content-between mb-4">
                     <h3>Gry</h3>
                     <div>
-                        <a href="{% url 'group-games' season_number=object.season.number group_name=object.name %}" class="btn btn-primary me-2">
-                            <i class="fa fa-list"></i> {% translate "Gry według rund" %}
-                        </a>
-                        <a href="{% url 'group-all-games' season_number=object.season.number group_name=object.name %}" class="btn btn-primary">
-                            <i class="fa fa-th-list"></i> {% translate "Wszystkie gry" %}
-                        </a>
                         {% if user|has_role:'referee' %}
                             {% if group.season.state == "in_progress" and group.type == "mcmahon" and group.all_games_finished %}
-                                <form method="post" class="d-inline-block ms-2">{% csrf_token %}
+                                <form method="post" class="d-inline-block">{% csrf_token %}
                                     <button type="submit" class="btn btn-primary" name="action-pairing">
                                         <i class="fa fa-table"></i> {% blocktrans %}Nowa runda{% endblocktrans %}
                                     </button>

--- a/iglo/templates/league/group_games.html
+++ b/iglo/templates/league/group_games.html
@@ -1,0 +1,138 @@
+{% extends "base.html" %}
+
+{% load static i18n %}
+
+{% block page_title %}{% translate "Sezon" %} #{{ object.season.number }} - {% translate "Grupa" %}
+    {{ object.name }} - {% translate "Gry" %}{% endblock %}
+
+{% block content %}
+    <div class="row">
+        <div class="col">
+            <nav aria-label="breadcrumb">
+                <ol class="breadcrumb">
+                    <li class="breadcrumb-item">
+                        <a href="{% url "seasons-list" %}">{% translate "Sezony" %}</a>
+                    </li>
+                    <li class="breadcrumb-item">
+                        <a href="{% url "season-detail" object.season.number %}">
+                            {% translate "Sezon" %} #{{ object.season.number }}
+                        </a>
+                    </li>
+                    <li class="breadcrumb-item">
+                        <a href="{% url "group-detail" season_number=object.season.number group_name=object.name %}">
+                            {% translate "Grupa" %} {{ object.name }}
+                        </a>
+                    </li>
+                    <li class="breadcrumb-item active" aria-current="page">
+                        {% translate "Gry" %}
+                    </li>
+                </ol>
+            </nav>
+            <div class="d-flex align-items-center mb-3 flex-wrap">
+                <h2>{% translate "Grupa" %} {{ object.name }} - {% translate "Gry" %}</h2>
+                <span class="badge bg-secondary ms-2">{{ group.get_type_display | upper }}</span>
+            </div>
+            
+            <div class="d-flex mb-2 small text-muted align-items-center">
+                <i class="fas fa-info-circle me-1"></i>
+                <span>{% translate "Gry oznaczone" %} <span class="badge bg-info">EGD</span> {% translate "są raportowane do European Go Database." %}</span>
+            </div>
+            
+            <div class="d-flex justify-content-between mb-4">
+                <h3>{% translate "Gry" %}</h3>
+                <div>
+                    <a href="{% url 'group-detail' season_number=object.season.number group_name=object.name %}" class="btn btn-secondary">
+                        <i class="fa fa-arrow-left"></i> {% translate "Powrót do widoku grupy" %}
+                    </a>
+                    {% if user|has_role:'referee' %}
+                        {% if group.season.state == "in_progress" and group.type == "mcmahon" and group.all_games_finished %}
+                            <form method="post" class="d-inline-block">{% csrf_token %}
+                                <button type="submit" class="btn btn-primary" name="action-pairing">
+                                    <i class="fa fa-table"></i> {% blocktrans %}Nowa runda{% endblocktrans %}
+                                </button>
+                            </form>
+                        {% endif %}
+                        {% if group.all_games_finished %}
+                            <a href="{% url "group-egd-export" season_number=group.season.number group_name=group.name %}"
+                               class="btn btn-primary">
+                                <i class="fa fa-file-export"></i> {% blocktrans %}Eksport EGD{% endblocktrans %}
+                            </a>
+                        {% endif %}
+                    {% endif %}
+                </div>
+            </div>
+            
+            {% for round in object.rounds.all %}
+                <div class="card mb-3">
+                    <div class="card-header d-flex justify-content-between align-items-center clickable flex-column flex-md-row align-items-stretch align-items-md-baseline"
+                         onClick="toggle_collapse(event)" data-target="round-{{ forloop.counter }}">
+                        <div class="d-flex flex-grow-1">
+                            <strong class="flex-grow-1">{% translate "Runda" %} #{{ round.number }}</strong>
+                            <div>
+                                {% if round.start_date and round.end_date %}{{ round.start_date }} -
+                                    {{ round.end_date }}{% endif %}
+                            </div>
+                        </div>
+                        <button class="btn" onClick="toggle_collapse(event)"
+                                data-target="round-{{ forloop.counter }}">
+                            <i id="collapse-round-{{ forloop.counter }}" style="pointer-events: none;" class="fas
+                               {% if round.is_current %} fa-chevron-up {% else %} fa-chevron-down {% endif %}"></i>
+                        </button>
+                    </div>
+                    <div class="card-body collapse {% if round.is_current %}show{% endif %}"
+                         id="round-{{ forloop.counter }}">
+                        {% for game in round.games.all %}
+                            <div class="card mb-3 {% if not game.is_bye and game.is_egd_eligible %}border-info{% endif %}">
+                                <div class="card-header d-flex justify-content-between {% if not game.is_bye and game.is_egd_eligible %}bg-light{% endif %}">
+                                <span>
+                                    {% if game.is_bye %}
+                                        {% translate "Bye" %}:
+                                        {% include "league/includes/player_badge.html" with player=game.winner.player member=game.winner %}
+                                    {% else %}
+                                        {% include "league/includes/game_players.html" with game=game %}
+                                        {% if game.is_egd_eligible %}
+                                            <span class="badge bg-info ms-2" title="{% translate 'This game is eligible for EGD export' %}">EGD</span>
+                                        {% endif %}
+                                    {% endif %}
+                                </span>
+                                    {% if game.date and not game.is_bye %}
+                                        <span>
+                                            {{ game.date }}
+                                            {% if game.is_delayed %}
+                                                <i class="fas fa-exclamation-triangle text-danger"
+                                                   data-bs-toggle="tooltip" data-bs-placement="top"
+                                                   title="{% translate "Ta gra nie została rozegrana w terminie" %}"></i>
+                                            {% endif %}
+                                        </span>
+                                    {% endif %}
+                                </div>
+                                <div class="card-body d-flex justify-content-between align-items-baseline flex-wrap">
+                                    <p>
+                                        {% if game.is_played %}
+                                            {{ game | result }}
+                                        {% else %}
+                                            {% blocktrans trimmed %}Gra jeszcze się nie odbyła.{% endblocktrans %}
+                                        {% endif %}
+                                    </p>
+                                    <div>
+                                        {% include "league/includes/game_actions.html" with show_link=True %}
+                                    </div>
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+    <script>
+        function toggle_collapse(event) {
+            event.stopPropagation();
+            element_id = event.target.getAttribute('data-target');
+            document.getElementById(element_id).classList.toggle('show');
+            icon_id = 'collapse-' + element_id;
+            document.getElementById(icon_id).classList.toggle('fa-chevron-down');
+            document.getElementById(icon_id).classList.toggle('fa-chevron-up');
+        }
+    </script>
+{% endblock %}

--- a/iglo/templates/league/group_games.html
+++ b/iglo/templates/league/group_games.html
@@ -39,14 +39,17 @@
             </div>
             
             <div class="d-flex justify-content-between mb-4">
-                <h3>{% translate "Gry" %}</h3>
+                <h3>{% translate "Gry według rund" %}</h3>
                 <div>
+                    <a href="{% url 'group-all-games' season_number=object.season.number group_name=object.name %}" class="btn btn-primary me-2">
+                        <i class="fa fa-th-list"></i> {% translate "Wszystkie gry" %}
+                    </a>
                     <a href="{% url 'group-detail' season_number=object.season.number group_name=object.name %}" class="btn btn-secondary">
                         <i class="fa fa-arrow-left"></i> {% translate "Powrót do widoku grupy" %}
                     </a>
                     {% if user|has_role:'referee' %}
                         {% if group.season.state == "in_progress" and group.type == "mcmahon" and group.all_games_finished %}
-                            <form method="post" class="d-inline-block">{% csrf_token %}
+                            <form method="post" class="d-inline-block ms-2">{% csrf_token %}
                                 <button type="submit" class="btn btn-primary" name="action-pairing">
                                     <i class="fa fa-table"></i> {% blocktrans %}Nowa runda{% endblocktrans %}
                                 </button>
@@ -54,7 +57,7 @@
                         {% endif %}
                         {% if group.all_games_finished %}
                             <a href="{% url "group-egd-export" season_number=group.season.number group_name=group.name %}"
-                               class="btn btn-primary">
+                               class="btn btn-primary ms-2">
                                 <i class="fa fa-file-export"></i> {% blocktrans %}Eksport EGD{% endblocktrans %}
                             </a>
                         {% endif %}


### PR DESCRIPTION
# Add Alternative Game Views for League Groups

## Summary

This PR introduces two new dedicated views for displaying games in a league group, offering different ways to browse and organize game information:

1. **View by Rounds**: Games organized into collapsible rounds (original functionality extracted to a dedicated view)
2. **Alternative View**: A compact table view of all games sorted by player ranking positions

The alternative view includes powerful features for teachers, such as the ability to partition games into color-coded groups for easier assignment and review management.

## Changes Overview

### New Files
- `iglo/templates/league/group_games.html` - Template for viewing games organized by rounds
- `iglo/templates/league/group_all_games.html` - Template for the new alternative view with player-sorted games

### Modified Files
- `iglo/league/views.py` - Added two new view classes: `GroupGamesView` and `GroupAllGamesView`
- `iglo/league/urls.py` - Added URL routes for the new views
- `iglo/templates/league/group_detail.html` - Moved game display to dedicated views, added navigation buttons

## Key Features

### Round-Based View
- Maintains the original functionality but in a dedicated view
- All rounds shown in collapsible sections with game information

### Alternative "All Games" View
- **Compact Table Format**: One line per game for easier scanning
- **Custom Sorting**: Games sorted by player position (lexicographically, higher player first then lower player)
- **Bye Games Excluded**: Only shows games between players
- **Teacher Grouping Tool**: Dynamic dropdown to partition games into color-coded groups
- **Visual Enhancements**:
  - Supporter badges for patrons
  - Review column showing available reviews with links
  - Group column that appears when grouping is active
  - Clickable player names linking to player profiles

### UI/UX Improvements
- Game view navigation buttons moved to the top of each page for better accessibility
- Consistent styling and visual indicators
- Improved terminology with "Grupa Nauczycielska" for better context

## Testing Steps

1. Navigate to any group detail page
2. Use the "Gry według rund" and "Wszystkie gry" buttons in the header to switch between views
3. In the alternative view, try the "Grupuj dla Nauczycieli" dropdown to see the color-coded grouping feature
4. Check that supporter badges and review links work correctly
5. Verify both views contain the same game information but presented differently

## Technical Implementation Notes

- The player sorting algorithm uses `min(black.order, white.order)` and `max(black.order, white.order)` to ensure consistent ordering regardless of which player has which color
- Grouping is implemented with client-side JavaScript that dynamically applies background colors and shows/hides the group column
- The grouping dropdown is populated dynamically based on the actual number of games in the grouplew@fedora ~/devel/iglo (games_view2) $ 

